### PR TITLE
docs: add missing extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ keep_tf_tree: true
 splits:
   - start:  1676549454.0
     end:    1676549554.0
-    name:   beginning
+    name:   beginning.mcap
   - start:  1676549554.0
     end:    1676549654.0
     name:   end.mcap


### PR DESCRIPTION
- add missing mcap extension in the README.md