### PR TITLE
feat: added msg interface upgrader plugin

### DIFF
--- a/src/kappe/cli.py
+++ b/src/kappe/cli.py
@@ -125,7 +125,7 @@ class KappeCLI:
         topic: SettingTopic | None = None,
         tf_static: SettingTF | None = None,
         msg_schema: SettingSchema | None = None,
-        msg_folder: Path | None = Path('./msgs'),
+        msg_folders: list[Path] | None = [Path('./msgs')],
         point_cloud: dict[str, SettingPointCloud] | None = None,
         time_offset: dict[str, SettingTimeOffset] | None = None,
         plugins: list[SettingPlugin] | None = None,
@@ -144,7 +144,7 @@ class KappeCLI:
             topic: Migrations for topics (remove, rename, etc.).
             tf_static: Migrations for TF (insert, remove).
             msg_schema: Updating or changing a schema.
-            msg_folder: Path to the folder containing .msg files used to change the schema and
+            msg_folders: Paths to the folder containing .msg files used to change the schema and
                 upgrading from ROS1.
             point_cloud: Migrations for point clouds (Update filed, rotate, etc.).
             time_offset: Migrations for time (Add offset, sync with mcap time, etc.).
@@ -183,15 +183,15 @@ class KappeCLI:
         config.time_start = time_start
         config.time_end = time_end
         config.keep_all_static_tf = keep_all_static_tf
-        config.msg_folder = msg_folder
+        config.msg_folders = msg_folders
         config.plugin_folder = plugin_folder
         config.progress = self.progress
         config.save_metadata = save_metadata
 
         # check for msgs folder
-        if msg_folder is not None and not msg_folder.exists():
-            logger.warning('msg_folder does not exist: %s', msg_folder)
-            msg_folder = None
+        for folder in msg_folders:
+            if not folder.exists():
+                logger.warning('msg_folders does not exist: %s', folder)
 
         errors = False
 

--- a/src/kappe/plugin.py
+++ b/src/kappe/plugin.py
@@ -5,6 +5,7 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from types import ModuleType
 from typing import Any
+from mcap.records import Schema
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,7 @@ logger = logging.getLogger(__name__)
 class ConverterPlugin(ABC):
     def __init__(self, **_kwargs: Any) -> None:
         self.logger = logging.getLogger(self.__class__.__name__)
+        self._schema: Schema = None
 
     @property
     @abstractmethod
@@ -19,8 +21,15 @@ class ConverterPlugin(ABC):
         pass
 
     @abstractmethod
-    def convert(self, ros_msg: Any) -> Any:
+    def convert(self, ros_msg: Any, *args: Any) -> Any:
         pass
+
+    def set_output_schema(self, data: Schema) -> None:
+        self._schema = data
+    
+    @property
+    def output_schema_data(self) -> Schema:
+        return self._schema
 
 
 def module_get_plugins(module: ModuleType) -> list[str]:

--- a/src/kappe/plugins/upgrade.py
+++ b/src/kappe/plugins/upgrade.py
@@ -1,0 +1,146 @@
+"""
+This plugin can be used with Kappe to 'upgrade' interfaces to the newest version. Before you can use the plugin you must have the
+newest interface package colcon built. You then want to provide the path to the msg folder containing the desired interface, which
+is usually in the install > package_name > share > package_name > msg folder.
+
+PLUGIN CONFIG FILE STRUCTURE:
+
+msg_folders: ['/home/path/to/your/msg/folder']
+plugins:
+  - name: upgrade.UpgradeInterfaceMsgs
+    input_topic: /old-topic_name-you-want-to-upgrade
+    output_topic: /new-topic_name-you-want-to-upgrade # NOTE Can be the same name as the input topic
+    settings:
+      interface_type: new_interface_package_name/msg/new_msg_name # i.e. car_interfaces/msg/Car
+      interface_definition: new_interface_package_name/new_msg_name # i.e. car_interfaces/Car
+      old_type_hash: old_topic_type_hash
+      new_type_hash: new_topic_type_hash
+
+EXAMPLE PLUGIN CONFIG FILE:
+
+msg_folders: ['/ros_ws/install/car_interfaces/share/car_interfaces/msg']
+plugins:
+  - name: upgrade.UpgradeInterfaceMsgs
+    input_topic: /car_info
+    output_topic: /car_info
+    settings:
+      interface_type: car_interfaces/msg/Car
+      interface_definition: car_interfaces/Car
+      old_type_hash: RIHS01_3e8dc9e2a1254b4b8a1b534db3e6172a8b14f10b5a36e3c3b3ec4f34a8e6b5a2
+      new_type_hash: RIHS01_7b8ef0b1c2a94a4ba8d8c5f603c8a2a2b5c4f10b5a36e3c3b3ec4f34a8e6b5b3
+"""
+
+from typing import Any
+
+from mcap.records import Channel
+from mcap_ros2._dynamic import TimeDefinition, _for_each_msgdef, encode_message, read_message
+from mcap_ros2._vendor.rosidl_adapter.parser import MessageSpecification
+
+from kappe.plugin import ConverterPlugin
+
+
+class UpgradeInterfaceMsgs(ConverterPlugin):
+    def __init__(
+        self,
+        *,
+        interface_type: str,
+        interface_definition: str,
+        old_type_hash: str,
+        new_type_hash: str,
+    ) -> None:
+        super().__init__()
+        self.interface_type = interface_type
+        self.interface_definition = interface_definition
+        self.old_type_hash = old_type_hash
+        self.new_type_hash = new_type_hash
+        self.checked_type_hash = False
+
+    def convert(self, ros_msg: Any, channel: Channel) -> Any:
+        # Get the definitions from the imported msgs
+        msg_defs = get_definitions(self._schema.name, self._schema.data.decode())
+
+        # Get the new message definition
+        new_msg_def = msg_defs.get(self.interface_definition)
+
+        # Create a default encoded message to use as a template to create new messages
+        default_encoded_msg = encode_message(self._schema.name, msg_defs, new_msg_def)
+
+        # Create a new message object with required methods
+        msg = read_message(self._schema.name, msg_defs, default_encoded_msg)
+
+        # Check supplied mcap and topic contains the correct topic type hash
+        if (
+            channel.metadata.get('topic_type_hash') != self.old_type_hash
+            and not self.checked_type_hash
+        ):
+            raise ValueError(
+                f"MCAP file or topic does not contain the given topic type hash: {channel.metadata.get('topic_type_hash')}"
+            )
+        else:
+            self.checked_type_hash = True
+
+        """
+        EXAMPLE CONVERSION METHOD
+
+        ***The following is an example of an 'old' custom interface:
+
+        # Name of the car
+        string name
+
+        # The speed of the car in m/s
+        float32 speed
+
+        # Waypoints of where the car has travelled
+        geographic_msgs/GeoPoint[] waypoints
+
+        ***This interface has been updated to include a new entry, acceleration:
+
+        # Name of the car
+        string name
+
+        # The speed of the car in m/s
+        float32 speed
+
+        # Waypoints of where the car has travelled
+        geographic_msgs/GeoPoint[] waypoints
+
+        # The acceleration of the car in m/s^2
+        float32 acceleration
+
+        ***This is how the conversion would be implemented in this file. NOTE that the 'acceleration' field does not NEED to be explicitly defined as it will initialise to an 'empty' type:
+
+        new_car = {
+            "name": car.name,
+            "speed": car.speed,
+            for waypoint in car.waypoints:
+                "waypoints": waypoint
+            "acceleration": 0.0
+        }
+        msg.cars.append(new_car)
+        """
+
+        # IMPLEMENT YOUR CONVERSION BELOW
+
+        # Update the topic type hash
+        channel.metadata['topic_type_hash'] = self.new_type_hash
+
+        return msg
+
+    @property
+    def output_schema(self) -> str:
+        return self.interface_type
+
+
+def get_definitions(schema_name: str, schema_text: str) -> dict[str, MessageSpecification]:
+    msgdefs: dict[str, MessageSpecification] = {
+        'builtin_interfaces/Time': TimeDefinition,
+        'builtin_interfaces/Duration': TimeDefinition,
+    }
+
+    def handle_msgdef(cur_schema_name: str, short_name: str, msgdef: MessageSpecification):
+        # Add the message definition to the dictionary
+        msgdefs[cur_schema_name] = msgdef
+        msgdefs[short_name] = msgdef
+
+    _for_each_msgdef(schema_name, schema_text, handle_msgdef)
+    return msgdefs

--- a/src/kappe/settings.py
+++ b/src/kappe/settings.py
@@ -1,6 +1,6 @@
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import BaseModel
 
@@ -78,7 +78,7 @@ class Settings(BaseModel):
     :ivar time_start: Start time of the recording.
     :ivar time_end: End time of the recording.
     :ivar keep_all_static_tf: Keep all static TF frames.
-    :ivar msg_folder: Folder containing message definitions, defaults to ./msgs/.
+    :ivar msg_folders: Folder containing message definitions, defaults to ./msgs/.
     :ivar progress: Show progress bar.
     :ivar save_metadata: If true save the config as attachment in the new created mcap.
     """
@@ -97,7 +97,7 @@ class Settings(BaseModel):
 
     keep_all_static_tf: bool = False
 
-    msg_folder: Path | None = Path('./msgs')
+    msg_folders: Path | None = Path('./msgs')
     plugin_folder: Path | None = Path('./plugins')
 
     progress: bool = True


### PR DESCRIPTION
Hey,

My colleagues and I needed a method of easily upgrading msg interfaces within an MCAP file to a newer version. We thought this would be a good plugin addition to Kappe. It works by stating the desired topic name, topic types and topic type hashes in the .yaml and outlining how the data should be mapped from the old to the new schema. The plugin will update the target topic messages with the upgraded msg interface and change the `topic_type_hash` to the new version. Examples and further info of this plugin is outlined in the `upgrade.py`.

Also in this PR is some features and a fix that we required in order to get this plugin working. The fix was to allow Kappe to read sequence interface type, as previously it would error out. The other features were to allow multiple msg interfaces to be read and to allow dynamic changing of schemas.

Hopefully this is all suitable and helpeful.
Cheers.