### PR TITLE
Support protobuf (back again)

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -20,10 +20,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Bump, commit, tag and push
         id: bump

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: |
             Issue marked as stale because it has not had recent activity.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -42,10 +42,10 @@ jobs:
         version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - run: uv run -p ${{ matrix.version }} ./src/kappe/cli.py version
 
@@ -74,10 +74,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Building
         run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "mcap>=1.0.2",
     "mcap-ros1-support>=0.6.0",
     "mcap-ros2-support>=0.3.0",
+    "mcap-protobuf-support>=0.5.3",
     "numpy",
     "pydantic>=2.4.2",
     "tqdm",

--- a/src/kappe/plugin.py
+++ b/src/kappe/plugin.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from google.protobuf.descriptor import Descriptor
+
 logger = logging.getLogger(__name__)
 
 
@@ -22,6 +24,22 @@ class ConverterPlugin(ABC):
     @abstractmethod
     def convert(self, ros_msg: Any) -> Any:
         pass
+
+    def convert_with_times(self, ros_msg: Any, log_time_ns: int, publish_time_ns: int) -> Any:  # noqa: ARG002
+        # by default return the convert result
+        # implement this instead of convert if you need to have access to mcap times
+        return self.convert(ros_msg)
+
+
+class ProtobufConverterPlugin(ConverterPlugin):
+    @property
+    @abstractmethod
+    def descriptor(self) -> Descriptor:
+        pass
+
+    @property
+    def output_schema(self) -> str:
+        return self.descriptor.full_name
 
 
 def module_get_plugins(module: ModuleType) -> list[str]:

--- a/src/kappe/plugin.py
+++ b/src/kappe/plugin.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -49,7 +50,7 @@ def module_get_plugins(module: ModuleType) -> list[str]:
         for cls in dir(module)
         if isinstance(getattr(module, cls), type)
         and issubclass(getattr(module, cls), ConverterPlugin)
-        and cls != 'ConverterPlugin'
+        and not inspect.isabstract(getattr(module, cls))
     ]
 
 

--- a/src/kappe/utils/mcap_to_json.py
+++ b/src/kappe/utils/mcap_to_json.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import IO, Any
 
 from mcap.reader import make_reader
+from mcap_protobuf.decoder import DecoderFactory as ProtobufDecoderFactory
 from mcap_ros2.decoder import DecoderFactory as Ros2DecoderFactory
 from pointcloud2 import read_points
 
@@ -68,7 +69,9 @@ def _iter_jsonl(
 
     try:
         with file_path.open('rb') as f:
-            reader = make_reader(f, decoder_factories=[Ros2DecoderFactory()])
+            reader = make_reader(
+                f, decoder_factories=[Ros2DecoderFactory(), ProtobufDecoderFactory()]
+            )
             for i, record in enumerate(
                 reader.iter_decoded_messages(
                     topics=topics,

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -4,8 +4,10 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.protobuf import descriptor_pb2
+from google.protobuf.descriptor import Descriptor
 
-from kappe.plugin import ConverterPlugin, load_plugin, module_get_plugins
+from kappe.plugin import ConverterPlugin, ProtobufConverterPlugin, load_plugin, module_get_plugins
 
 
 class _OneConverterPlugin(ConverterPlugin):
@@ -239,3 +241,71 @@ class Converter(ConverterPlugin):
 
         with pytest.raises(ValueError, match='Plugin file loader_none_plugin does not exist'):
             load_plugin(tmp_path, 'loader_none_plugin')
+
+
+class _ConcreteProtobufPlugin(ProtobufConverterPlugin):
+    """Concrete protobuf converter plugin for testing."""
+
+    @property
+    def descriptor(self) -> Descriptor:
+        return descriptor_pb2.FileDescriptorProto.DESCRIPTOR
+
+    def convert(self, ros_msg: Any) -> Any:
+        return ros_msg
+
+
+def test_protobuf_converter_plugin_abstract():
+    """Test that ProtobufConverterPlugin is abstract and requires descriptor implementation."""
+    with pytest.raises(TypeError):
+        ProtobufConverterPlugin()  # type: ignore[abstract]
+
+
+def test_protobuf_converter_plugin_output_schema():
+    """Test that ProtobufConverterPlugin.output_schema returns descriptor full_name."""
+    plugin = _ConcreteProtobufPlugin()
+    assert plugin.output_schema == descriptor_pb2.FileDescriptorProto.DESCRIPTOR.full_name
+    assert plugin.output_schema == 'google.protobuf.FileDescriptorProto'
+
+
+def test_protobuf_converter_plugin_is_subclass():
+    """Test that ProtobufConverterPlugin is a subclass of ConverterPlugin."""
+    assert issubclass(ProtobufConverterPlugin, ConverterPlugin)
+    plugin = _ConcreteProtobufPlugin()
+    assert isinstance(plugin, ConverterPlugin)
+    assert isinstance(plugin, ProtobufConverterPlugin)
+
+
+def test_protobuf_converter_plugin_convert_with_times():
+    """Test that convert_with_times delegates to convert by default."""
+    plugin = _ConcreteProtobufPlugin()
+    msg = {'test': 'data'}
+    result = plugin.convert_with_times(msg, log_time_ns=100, publish_time_ns=200)
+    assert result == msg
+
+
+def test_converter_plugin_convert_with_times_default():
+    """Test that ConverterPlugin.convert_with_times calls convert by default."""
+    plugin = _OneConverterPlugin()
+    msg = {'test': 'data'}
+    result = plugin.convert_with_times(msg, log_time_ns=100, publish_time_ns=200)
+    assert result == {'converted': msg}
+
+
+def test_module_get_plugins_excludes_abstract_classes():
+    """Test that module_get_plugins excludes ProtobufConverterPlugin base class."""
+    mock_module = MagicMock()
+    mock_module.__dict__ = {
+        'ConcreteProtobufPlugin': _ConcreteProtobufPlugin,
+        'ConverterPlugin': ConverterPlugin,
+        'ProtobufConverterPlugin': ProtobufConverterPlugin,
+    }
+
+    with (
+        patch('kappe.plugin.dir', return_value=list(mock_module.__dict__.keys())),
+        patch('kappe.plugin.getattr', side_effect=lambda _, k: mock_module.__dict__[k]),
+    ):
+        plugins = module_get_plugins(mock_module)
+
+    assert 'ConcreteProtobufPlugin' in plugins
+    assert 'ConverterPlugin' not in plugins
+    assert 'ProtobufConverterPlugin' not in plugins

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -1,0 +1,172 @@
+"""Tests for the writer module's protobuf encoding/decoding support."""
+
+from io import BytesIO
+
+import pytest
+from google.protobuf import descriptor_pb2
+from mcap.records import Schema
+from mcap.well_known import SchemaEncoding
+
+from kappe.writer import (
+    ROS2EncodeError,
+    WrappedWriter,
+    build_file_descriptor_set,
+    get_decoder,
+    get_encoder,
+)
+
+
+def _make_protobuf_schema() -> Schema:
+    """Create a Schema record for google.protobuf.FileDescriptorProto."""
+    descriptor = descriptor_pb2.FileDescriptorProto.DESCRIPTOR
+    fds = build_file_descriptor_set(descriptor)
+    return Schema(
+        id=1,
+        name=descriptor.full_name,
+        encoding=SchemaEncoding.Protobuf,
+        data=fds.SerializeToString(),
+    )
+
+
+def test_build_file_descriptor_set_basic():
+    """Test that build_file_descriptor_set creates a valid FileDescriptorSet."""
+    descriptor = descriptor_pb2.FileDescriptorProto.DESCRIPTOR
+    fds = build_file_descriptor_set(descriptor)
+
+    assert len(fds.file) >= 1
+    # The descriptor's own file should be the last entry
+    file_names = [f.name for f in fds.file]
+    assert descriptor.file.name in file_names
+
+
+def test_build_file_descriptor_set_with_dependencies():
+    """Test that build_file_descriptor_set includes all transitive dependencies."""
+    # FileDescriptorSet has dependencies (e.g. google/protobuf/descriptor.proto)
+    descriptor = descriptor_pb2.FileDescriptorSet.DESCRIPTOR
+    fds = build_file_descriptor_set(descriptor)
+
+    file_names = [f.name for f in fds.file]
+    assert descriptor.file.name in file_names
+    # All dependencies should be included
+    for dep in descriptor.file.dependencies:
+        assert dep.name in file_names
+
+
+def test_get_decoder_protobuf():
+    """Test that get_decoder returns a working decoder for protobuf schemas."""
+    schema = _make_protobuf_schema()
+    decoder = get_decoder(schema)
+    assert callable(decoder)
+
+    # Create a sample protobuf message and encode it
+    msg = descriptor_pb2.FileDescriptorProto()
+    msg.name = 'test.proto'
+    encoded = msg.SerializeToString()
+
+    # Decode using our decoder
+    decoded = decoder(encoded)
+    assert decoded.name == 'test.proto'
+
+
+def test_get_decoder_protobuf_caching():
+    """Test that get_decoder caches decoders for protobuf schemas."""
+    schema = _make_protobuf_schema()
+    decoder1 = get_decoder(schema)
+    decoder2 = get_decoder(schema)
+    # Same decoder object should be returned from cache
+    assert decoder1 is decoder2
+
+
+def test_get_encoder_protobuf():
+    """Test that get_encoder returns a working encoder for protobuf schemas."""
+    schema = _make_protobuf_schema()
+    encoder = get_encoder(schema)
+    assert callable(encoder)
+
+    # Create a sample protobuf message
+    msg = descriptor_pb2.FileDescriptorProto()
+    msg.name = 'test.proto'
+
+    # Encode using our encoder
+    encoded = encoder(msg)
+    assert isinstance(encoded, bytes)
+
+    # Verify it's valid protobuf by decoding
+    decoded = descriptor_pb2.FileDescriptorProto()
+    decoded.ParseFromString(encoded)
+    assert decoded.name == 'test.proto'
+
+
+def test_get_encoder_protobuf_roundtrip():
+    """Test that encoding and decoding a protobuf message yields the original message."""
+    schema = _make_protobuf_schema()
+    encoder = get_encoder(schema)
+    decoder = get_decoder(schema)
+
+    msg = descriptor_pb2.FileDescriptorProto()
+    msg.name = 'test.proto'
+    msg.syntax = 'proto3'
+
+    encoded = encoder(msg)
+    decoded = decoder(encoded)
+
+    assert decoded.name == msg.name
+    assert decoded.syntax == msg.syntax
+
+
+def test_get_encoder_unsupported_encoding():
+    """Test that get_encoder raises for unsupported encodings."""
+    schema = Schema(
+        id=99,
+        name='unknown/schema',
+        encoding=SchemaEncoding.JSONSchema,
+        data=b'{}',
+    )
+    with pytest.raises(ROS2EncodeError):
+        get_encoder(schema)
+
+
+def test_wrapped_writer_register_protobuf():
+    """Test that WrappedWriter.register_protobuf creates the correct Schema."""
+    buf = BytesIO()
+    with WrappedWriter(buf) as writer:
+        descriptor = descriptor_pb2.FileDescriptorProto.DESCRIPTOR
+        schema = writer.register_protobuf(descriptor.full_name, descriptor)
+
+    assert schema.name == descriptor.full_name
+    assert schema.encoding == SchemaEncoding.Protobuf
+    assert len(schema.data) > 0
+
+
+def test_wrapped_writer_write_protobuf_message():
+    """Test that WrappedWriter can write a protobuf message."""
+    buf = BytesIO()
+    with WrappedWriter(buf) as writer:
+        descriptor = descriptor_pb2.FileDescriptorProto.DESCRIPTOR
+        schema = writer.register_protobuf(descriptor.full_name, descriptor)
+
+        msg = descriptor_pb2.FileDescriptorProto()
+        msg.name = 'test.proto'
+        writer.write_message('/test_topic', schema, msg, log_time=1000, publish_time=1000)
+
+    # Should have written something
+    assert len(buf.getvalue()) > 0
+
+
+def test_wrapped_writer_register_schema_passthrough():
+    """Test that WrappedWriter.register_schema passes through the schema."""
+    buf = BytesIO()
+    with WrappedWriter(buf) as writer:
+        descriptor = descriptor_pb2.FileDescriptorProto.DESCRIPTOR
+        fds = build_file_descriptor_set(descriptor)
+        original_schema = Schema(
+            id=42,
+            name=descriptor.full_name,
+            encoding=SchemaEncoding.Protobuf,
+            data=fds.SerializeToString(),
+        )
+        registered = writer.register_schema(original_schema)
+
+    assert registered.name == original_schema.name
+    assert registered.encoding == original_schema.encoding
+    assert registered.data == original_schema.data


### PR DESCRIPTION
Hello,
As a follow up to my previous PR (https://github.com/sensmore/kappe/pull/18), I've rebased my work to support protobuf messages onto your recent refacto.

The main addition is the `ProtobufConverterPlugin` that allows user to create plugins for protobuf messages.

I've also added unit test and made sure my changes won't break your current features.

Hopefully, you think this is a good addition :)

Good work otherwise.